### PR TITLE
Handle infeasability

### DIFF
--- a/src/simulations/modeling/simulations.py
+++ b/src/simulations/modeling/simulations.py
@@ -35,7 +35,7 @@ def simulate(model, biomass_reaction, method, objective_id, objective_direction)
     try:
         logger.info(f"Simulating model {model.id} with {method}")
         if method == "fba":
-            solution = model.optimize()
+            solution = model.optimize(raise_error=True)
         elif method == "pfba":
             solution = pfba(model)
         elif method == "fva":

--- a/src/simulations/modeling/simulations.py
+++ b/src/simulations/modeling/simulations.py
@@ -47,7 +47,9 @@ def simulate(model, biomass_reaction, method, objective_id, objective_direction)
                 model, fraction_of_optimum=1, pfba_factor=1.05
             )
     except OptimizationError as error:
-        logger.info(f"Optimization Error: {error}")
+        logger.info(
+            f"Optimization Error: {error} (solver status: {model.solver.status})"
+        )
         raise
     else:
         logger.info(f"Simulation completed successfully")

--- a/src/simulations/modeling/simulations.py
+++ b/src/simulations/modeling/simulations.py
@@ -48,8 +48,7 @@ def simulate(model, biomass_reaction, method, objective_id, objective_direction)
             )
     except OptimizationError as error:
         logger.info(f"Optimization Error: {error}")
-        flux_distribution = {}
-        growth_rate = 0.0
+        raise
     else:
         logger.info(f"Simulation completed successfully")
         if method in ("fba", "pfba"):
@@ -63,5 +62,4 @@ def simulate(model, biomass_reaction, method, objective_id, objective_direction)
                 df[key] = df[key].astype("float")
             flux_distribution = df.T.to_dict()
             growth_rate = flux_distribution[biomass_reaction]["upper_bound"]
-
-    return flux_distribution, growth_rate
+        return flux_distribution, growth_rate

--- a/src/simulations/resources.py
+++ b/src/simulations/resources.py
@@ -126,11 +126,11 @@ def model_simulate(model_id, method, objective_id, objective_direction, operatio
                 objective_direction,
             )
         except OptimizationError:
-            return jsonify({"status": "infeasible"})
+            return jsonify({"status": model.solver.status})
         else:
             return jsonify(
                 {
-                    "status": "optimal",
+                    "status": model.solver.status,
                     "flux_distribution": flux_distribution,
                     "growth_rate": growth_rate,
                 }

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -69,9 +69,9 @@ def test_simulate_no_operations(client, models):
 def test_simulate_infeasible(client, models):
     measurements = [
         {
-            "id": "ATPM",
+            "id": "BIOMASS_Ec_iJO1366_core_53p95M",
             "namespace": "bigg.reaction",
-            "measurements": [100, 100],
+            "measurements": [-1000, -1000],
             "type": "reaction",
         }
     ]

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -72,7 +72,8 @@ def test_simulate_infeasible(client, models):
         {
             "id": "BIOMASS_Ec_iJO1366_core_53p95M",
             "namespace": "bigg.reaction",
-            "measurements": [-1000, -1000],
+            # Force an impossible growth to ensure infeasability
+            "measurements": [1000],
             "type": "reaction",
         }
     ]

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -85,7 +85,7 @@ def test_simulate_infeasible(client, models):
         "/simulate", json={"model_id": models["iJO1366"], "operations": operations}
     )
     assert response.status_code == 200
-    assert response.json["flux_distribution"]["ATPM"] == pytest.approx(100)
+    assert response.json["status"] == "infeasible"
 
 
 def test_simulate_fluxomics(monkeypatch, client, models):

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -64,6 +64,7 @@ def test_simulate_unauthorized(client, models):
 def test_simulate_no_operations(client, models):
     response = client.post("/simulate", json={"model_id": models["iJO1366"]})
     assert response.status_code == 200
+    assert response.json["status"] == "optimal"
 
 
 def test_simulate_infeasible(client, models):
@@ -99,6 +100,7 @@ def test_simulate_fluxomics(monkeypatch, client, models):
         "/simulate", json={"model_id": models["iJO1366"], "operations": operations}
     )
     assert response.status_code == 200
+    assert response.json["status"] == "optimal"
     assert response.json["flux_distribution"]["EX_glc__D_e"] == -9.0
     assert (
         abs(response.json["flux_distribution"]["EX_etoh_e"] - 4.64) < 0.001
@@ -149,6 +151,7 @@ def test_simulate_modify(monkeypatch, client, models):
         },
     )
     assert response.status_code == 200
+    assert response.json["status"] == "optimal"
     fluxes = response.json["flux_distribution"]
 
     assert fluxes["EX_glc__D_e"] == -9.0
@@ -162,11 +165,13 @@ def test_simulate_different_objective(client, models):
     )
     assert response.status_code == 200
     result = response.json
+    assert result["status"] == "optimal"
     assert abs(result["flux_distribution"]["EX_etoh_e"]) == pytest.approx(20)
 
     response = client.post("/simulate", json={"model_id": models["iJO1366"]})
     assert response.status_code == 200
     result = response.json
+    assert result["status"] == "optimal"
     assert abs(result["flux_distribution"]["EX_etoh_e"]) == pytest.approx(0)
 
 
@@ -380,6 +385,7 @@ def test_prokaryomics_md120_bw25113(client, models):
         json={"model_id": models["iJO1366"], "operations": response.json["operations"]},
     )
     assert response.status_code == 200
+    assert response.json["status"] == "optimal"
     assert response.json["growth_rate"] == pytest.approx(0.5134445454218568)
 
 
@@ -395,4 +401,5 @@ def test_growth_rate_measurement(client, models):
         json={"model_id": models["iJO1366"], "operations": response.json["operations"]},
     )
     assert response.status_code == 200
+    assert response.json["status"] == "optimal"
     assert response.json["growth_rate"] == pytest.approx(0.285)


### PR DESCRIPTION
Adds a new `status` field to the return value of the simulation service which will have the value `infeasible` or `optimal`, and only in the latter case are growth and fluxes included.

Thoughts:
- We're still not using marshmallow schemas in this service, but let's do this in incremental steps
- I was considering just passing the `solution.status` field instead of explicitly defining "optimal" and "infeasible", but we have to do that anyway since it's inaccessible when `raise_error=True`.
- I think it makes sense to just keep the HTTP 200 status code since the request in itself was valid and successful, it is the business logic which is failing.
- Not sure if forcing growth bounds to (-1000, -1000) is the most intuitive way to guarantee an infeasible model, but it works...