### PR TITLE
fix: create demand reaction, not exchange reaction

### DIFF
--- a/src/simulations/modeling/adapter.py
+++ b/src/simulations/modeling/adapter.py
@@ -391,7 +391,9 @@ def apply_genotype(model, genotype_changes):
 
                 # Create an exchange reaction for the extracellular metabolite so that
                 # it may leave the system
-                exchange_reaction = model.add_boundary(metabolite_e)
+                exchange_reaction = model.add_boundary(
+                    metabolite_e, type="exchange", lb=0, ub=1000
+                )
                 operations.append(
                     {
                         "operation": "add",


### PR DESCRIPTION
The metabolite should be able to leave the system and a demand reaction
is the correct type for that.

See: https://cobrapy.readthedocs.io/en/latest/autoapi/cobra/core/model/index.html?highlight=add_boundary#cobra.core.model.Model.add_boundary