### PR TITLE
Fix/exchange rxns ecModels

### DIFF
--- a/src/simulations/modeling/adapter.py
+++ b/src/simulations/modeling/adapter.py
@@ -130,7 +130,7 @@ def apply_medium(model, medium):
             )
         except MetaboliteNotFound:
             warning = (
-                f"Cannot add medium compund '{compound.id}' - metabolite not found in "
+                f"Cannot add medium compound '{compound.id}' - metabolite not found in "
                 f"extracellular compartment '{extracellular}'"
             )
             warnings.append(warning)
@@ -542,10 +542,10 @@ def apply_measurements(
             logger.warning(warning)
             break
 
-    for uptake_rate in uptake_secretion_rates:
+    for rate in uptake_secretion_rates:
         try:
             metabolite = find_metabolite(
-                model, uptake_rate["identifier"], uptake_rate["namespace"], "e"
+                model, rate["identifier"], rate["namespace"], "e"
             )
         except MetaboliteNotFound as error:
             errors.append(str(error))
@@ -559,13 +559,10 @@ def apply_measurements(
                 )
                 continue
             exchange_reaction = next(iter(exchange_reactions))
-            lower_bound, upper_bound = bounds(
-                uptake_rate["measurement"], uptake_rate["uncertainty"]
-            )
+            lower_bound, upper_bound = bounds(rate["measurement"], rate["uncertainty"])
 
-            # data is adjusted assuming a forward exchange reaction, x <--
-            # (sign = -1), so if we instead actually have <-- x, then multiply with
-            # -1
+            # data is adjusted assuming a forward exchange reaction, i.e. x -->
+            # (sign = -1), so if we instead actually have --> x, then multiply with -1
             direction = exchange_reaction.metabolites[metabolite]
             if direction > 0:
                 lower_bound, upper_bound = -1 * lower_bound, -1 * upper_bound

--- a/src/simulations/resources.py
+++ b/src/simulations/resources.py
@@ -83,7 +83,7 @@ def model_modify(
         warnings = []
         errors = []
         if medium:
-            results = apply_medium(model, medium)
+            results = apply_medium(model, model_wrapper.is_ec_model, medium)
             operations.extend(results[0])
             warnings.extend(results[1])
             errors.extend(results[2])

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -197,7 +197,7 @@ def test_measurements_adapter_ec_model(eciML1515):
         [],
         growth_rate,
     )
-    # 2 operations (1 protein + 1 uptake + 1 secretion + growth rate) + 3 warnings
+    # 4 operations (1 protein + 1 uptake + 1 secretion + growth rate) + 3 warnings
     # (1 skipped protein + 2 removed proteins) are expected:
     assert len(operations) == 4
     assert len(warnings) == 3

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -38,7 +38,7 @@ def test_medium_adapter(iJO1366):
         {"name": "Baz", "identifier": "CHEBI:86244", "namespace": "chebi"},
         {"name": "Goo", "identifier": "CHEBI:131387", "namespace": "chebi"},
     ]
-    operations, warnings, errors = apply_medium(iJO1366, medium)
+    operations, warnings, errors = apply_medium(iJO1366, is_ec_model, medium)
     # 30 warnings are expected; 29 unique compounds not found in the model and 1
     # unmapped ion from the salts mapping
     assert len(warnings) == 30

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -59,6 +59,28 @@ def test_medium_adapter(iJO1366):
     )
 
 
+def test_medium_adapter_ec_model(eciML1515):
+    eciML1515, biomass_reaction, is_ec_model = eciML1515
+    medium = [
+        {"name": "glc", "identifier": "MNXM41", "namespace": "metanetx.chemical"},
+        {"name": "nh4", "identifier": "MNXM15", "namespace": "metanetx.chemical"},
+        {"name": "o2", "identifier": "MNXM4", "namespace": "metanetx.chemical"},
+    ]
+    operations, warnings, errors = apply_medium(eciML1515, is_ec_model, medium)
+    # 2 warnings are expected: trace metals (CHEBI:25517 and CHEBI:25368) not found in
+    # model, as eciML1515 does not have CHEBI ids.
+    assert len(warnings) == 2
+    assert len(errors) == 0
+    assert set(eciML1515.medium) == {
+        "EX_glc__D_e_REV",
+        "EX_nh4_e_REV",
+        "EX_o2_e_REV",
+    }
+    assert eciML1515.reactions.EX_glc__D_e_REV.upper_bound == +10
+    assert eciML1515.reactions.EX_nh4_e_REV.upper_bound == +1000
+    assert eciML1515.reactions.EX_o2_e_REV.upper_bound == +1000
+
+
 def test_genotype_adapter(monkeypatch, iJO1366):
     iJO1366, biomass_reaction, is_ec_model = iJO1366
 
@@ -123,7 +145,7 @@ def test_measurements_adapter(iJO1366):
     assert len(errors) == 0
 
 
-def test_proteomics_adapter(eciML1515):
+def test_measurements_adapter_ec_model(eciML1515):
     eciML1515, biomass_reaction, is_ec_model = eciML1515
     proteomics = [
         {
@@ -147,6 +169,22 @@ def test_proteomics_adapter(eciML1515):
             "uncertainty": 0,
         },
     ]
+    uptake_secretion_rates = [
+        {
+            "name": "glucose",
+            "identifier": "MNXM41",
+            "namespace": "metanetx.chemical",
+            "measurement": -9.8,
+            "uncertainty": 0,
+        },
+        {
+            "name": "ethanol",
+            "identifier": "MNXM303",
+            "namespace": "metanetx.chemical",
+            "measurement": 0.5,
+            "uncertainty": 0,
+        },
+    ]
     growth_rate = {"measurement": 0.1, "uncertainty": 0.01}
     operations, warnings, errors = apply_measurements(
         eciML1515,
@@ -155,12 +193,12 @@ def test_proteomics_adapter(eciML1515):
         [],
         [],
         proteomics,
-        [],
+        uptake_secretion_rates,
         [],
         growth_rate,
     )
-    # 2 operations (1 proteomics + growth rate) + 3 warnings (1 skipped protein + 2
-    # removed proteins) are expected:
-    assert len(operations) == 2
+    # 2 operations (1 protein + 1 uptake + 1 secretion + growth rate) + 3 warnings
+    # (1 skipped protein + 2 removed proteins) are expected:
+    assert len(operations) == 4
     assert len(warnings) == 3
     assert len(errors) == 0


### PR DESCRIPTION
solves https://github.com/DD-DeCaF/scrum/issues/1172

Exchange reactions of ecModels are now properly recognized when defining medium and/or uptake rates.