### PR TITLE
fix: bound assignment for reverse exchange rxns

### DIFF
--- a/src/simulations/modeling/adapter.py
+++ b/src/simulations/modeling/adapter.py
@@ -571,9 +571,12 @@ def apply_measurements(
 
             # data is adjusted assuming a forward exchange reaction, i.e. x -->
             # (sign = -1), so if we instead actually have --> x, then multiply with -1
+            # and flip lower bound and upper bound, to properly adjust for uncertainty,
+            # e.g. if measurement = 3 and uncertainty = 0.3, then:
+            # lb, ub = -1*(3 + 0.3), -1*(3 - 0.3) = -3.3, -2.7
             direction = exchange_reaction.metabolites[metabolite]
             if direction > 0:
-                lower_bound, upper_bound = -1 * lower_bound, -1 * upper_bound
+                lower_bound, upper_bound = -1 * upper_bound, -1 * lower_bound
             exchange_reaction.bounds = lower_bound, upper_bound
             operations.append(
                 {

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -175,7 +175,7 @@ def test_measurements_adapter_ec_model(eciML1515):
             "identifier": "MNXM41",
             "namespace": "metanetx.chemical",
             "measurement": -9.8,
-            "uncertainty": 0,
+            "uncertainty": 0.3,
         },
         {
             "name": "ethanol",


### PR DESCRIPTION
There is a problem when assigning uptake/secretion rates on exchange reactions that come in the non-standard direction `--> X`: The way that we handle them at the moment is just multiplying lower/upper bound by -1, e.g. if uptake rate is to be assigned = -3:
```python
lower_bound, upper_bound = -1 * (-3), -1 * (-3) = +3, +3
```
Similarly if secretion rate is to be assigned = +3:
```python
lower_bound, upper_bound = -1 * (+3), -1 * (+3) = -3, -3
```
However this breaks if we account for uncertainty of let’s say 0.3 in the uptake:
```python
lower_bound, upper_bound = -1 * (-3.3), -1 * (-2.7) = +3.3, +2.7  # inconsistent, LB > UB
```
And also in the secretion:
```python
lower_bound, upper_bound = -1 * (+2.7), -1 * (+3.3) = -2.7, -3.3  # also inconsistent, LB > UB
```

The solution is to swap LB for UB, as done here. It is also tested on `eciML1515`, which has non-standard directions for any uptake reaction. AFAICT there is no other part in the simulations service that uses this logic :)