### PR TITLE
feat: uptake/secretion rates in flexibilize_proteins

### DIFF
--- a/src/simulations/modeling/adapter.py
+++ b/src/simulations/modeling/adapter.py
@@ -464,7 +464,7 @@ def apply_measurements(
     # proteomics data and redefine the growth rate based on simulations.
     if growth_rate and proteomics and is_ec_model:
         growth_rate, proteomics, prot_warnings = flexibilize_proteomics(
-            model, biomass_reaction, growth_rate, proteomics
+            model, biomass_reaction, growth_rate, proteomics, uptake_secretion_rates
         )
         for warning in prot_warnings:
             warnings.append(warning)

--- a/src/simulations/modeling/driven.py
+++ b/src/simulations/modeling/driven.py
@@ -18,6 +18,9 @@ import numpy as np
 import pandas as pd
 from optlang.symbolics import Zero
 
+from simulations.exceptions import MetaboliteNotFound
+from simulations.modeling.cobra_helpers import find_metabolite, get_exchange_reaction
+
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +165,9 @@ def adjust_fluxes2model(
     return solution
 
 
-def flexibilize_proteomics(model, biomass_reaction, growth_rate, proteomics):
+def flexibilize_proteomics(
+    model, biomass_reaction, growth_rate, proteomics, uptake_secretion_rates
+):
     """
     Replace proteomics measurements with a set that enables the model to grow. Proteins
     are removed from the set iteratively based on sensitivity analysis (shadow prices).
@@ -177,6 +182,8 @@ def flexibilize_proteomics(model, biomass_reaction, growth_rate, proteomics):
         Growth rate, matching the `GrowthRate` schema.
     proteomics: list(dict)
         List of measurements matching the `Proteomics` schema.
+    uptake_secretion_rates: list(dict)
+        List of measurements matching the `UptakeSecretionRates` schema.
 
     Returns
     -------
@@ -187,6 +194,25 @@ def flexibilize_proteomics(model, biomass_reaction, growth_rate, proteomics):
     warnings: list(str)
         List of warnings with all flexibilized proteins.
     """
+
+    for rate in uptake_secretion_rates:
+        try:
+            metabolite = find_metabolite(
+                model, rate["identifier"], rate["namespace"], "e"
+            )
+        except MetaboliteNotFound:
+            # This error will already be raised by the adapter, so does not need to be
+            # logged twice:
+            continue
+        else:
+            exchange_reaction = get_exchange_reaction(
+                metabolite, True, consumption=rate["measurement"] < 0
+            )
+            # All exchange reactions in an ec_model have only positive fluxes, so we can
+            # simply assign the absolute value of the measurement:
+            exchange_reaction.bounds = bounds(
+                abs(rate["measurement"]), rate["uncertainty"]
+            )
 
     # reset growth rate in model:
     model.reactions.get_by_id(biomass_reaction).bounds = (0, 1000)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -145,6 +145,44 @@ def test_measurements_adapter(iJO1366):
     assert len(errors) == 0
 
 
+def test_measurements_adapter_errors(iJO1366):
+    # record unmatched metabolites and reactions as errors
+    iJO1366, biomass_reaction, is_ec_model = iJO1366
+    uptake_secretion_rates = [
+        {
+            "name": "not a match",
+            "identifier": "CHEBI:123456789",  # non-existing id
+            "namespace": "chebi",
+            "measurement": 4.9,
+            "uncertainty": 0,
+        },
+    ]
+    fluxomics = [
+        {
+            "name": "not a match",
+            "identifier": "ASDFGHJKL",  # non-existing id
+            "namespace": "bigg.reaction",
+            "measurement": 5,
+            "uncertainty": 0,
+        },
+    ]
+    operations, warnings, errors = apply_measurements(
+        iJO1366,
+        biomass_reaction,
+        is_ec_model,
+        fluxomics,
+        [],
+        [],
+        uptake_secretion_rates,
+        [],
+        None,
+    )
+    # 2 errors (metabolite not found + reaction not found) are expected:
+    assert len(operations) == 0
+    assert len(warnings) == 0
+    assert len(errors) == 2
+
+
 def test_measurements_adapter_ec_model(eciML1515):
     # successfully flexibilize -> apply kinetics + growth rate + only 1 protein
     eciML1515, biomass_reaction, is_ec_model = eciML1515

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -184,6 +184,13 @@ def test_measurements_adapter_ec_model(eciML1515):
             "measurement": 0.5,
             "uncertainty": 0,
         },
+        {
+            "name": "not a match",
+            "identifier": "asdfgh",
+            "namespace": "metanetx.chemical",
+            "measurement": 1,
+            "uncertainty": 0,
+        },
     ]
     growth_rate = {"measurement": 0.1, "uncertainty": 0.01}
     operations, warnings, errors = apply_measurements(
@@ -198,7 +205,7 @@ def test_measurements_adapter_ec_model(eciML1515):
         growth_rate,
     )
     # 4 operations (1 protein + 1 uptake + 1 secretion + growth rate) + 3 warnings
-    # (1 skipped protein + 2 removed proteins) are expected:
+    # (1 skipped protein + 2 removed proteins) + 1 error (unmatched rate) are expected:
     assert len(operations) == 4
     assert len(warnings) == 3
-    assert len(errors) == 0
+    assert len(errors) == 1


### PR DESCRIPTION
closes https://github.com/DD-DeCaF/scrum/issues/1162

uptake/secretion rates are now assigned when flexibilizing proteomics to ensure feasible simulations.