### PR TITLE
test: simulate each method only once

### DIFF
--- a/tests/unit/test_simulations.py
+++ b/tests/unit/test_simulations.py
@@ -31,9 +31,7 @@ def test_tmy_result(e_coli_core, objective):
 @pytest.mark.parametrize("method", METHODS)
 def test_simulation_methods(e_coli_core, method):
     e_coli_core, biomass_reaction, is_ec_model = e_coli_core
-    fluxes, growth_rate = simulate(
-        e_coli_core, biomass_reaction, method, None, None
-    )
+    fluxes, growth_rate = simulate(e_coli_core, biomass_reaction, method, None, None)
     if method not in {"fva", "pfba-fva"}:
         reactions_ids = [i.id for i in e_coli_core.reactions]
         assert set(fluxes) == set(reactions_ids)

--- a/tests/unit/test_simulations.py
+++ b/tests/unit/test_simulations.py
@@ -31,10 +31,9 @@ def test_tmy_result(e_coli_core, objective):
 @pytest.mark.parametrize("method", METHODS)
 def test_simulation_methods(e_coli_core, method):
     e_coli_core, biomass_reaction, is_ec_model = e_coli_core
-    for method in METHODS:
-        fluxes, growth_rate = simulate(
-            e_coli_core, biomass_reaction, method, None, None
-        )
-        if method not in {"fva", "pfba-fva"}:
-            reactions_ids = [i.id for i in e_coli_core.reactions]
-            assert set(fluxes) == set(reactions_ids)
+    fluxes, growth_rate = simulate(
+        e_coli_core, biomass_reaction, method, None, None
+    )
+    if method not in {"fva", "pfba-fva"}:
+        reactions_ids = [i.id for i in e_coli_core.reactions]
+        assert set(fluxes) == set(reactions_ids)


### PR DESCRIPTION
The test is already parametrized, so this was redundant.